### PR TITLE
fix: AthenaFrame should pass through all 'successful' ResolvedPatternTypes

### DIFF
--- a/src/main/java/miyucomics/overevaluate/frames/AthenaFrame.kt
+++ b/src/main/java/miyucomics/overevaluate/frames/AthenaFrame.kt
@@ -48,8 +48,14 @@ object AthenaFrame : ContinuationFrame {
 	@JvmStatic
 	fun handleAthena(iota: Iota, vm: CastingVM, world: ServerWorld, continuation: SpellContinuation, originalMethod: Operation<CastResult>): CastResult {
 		val original = originalMethod.call(iota, world, continuation)
-		if (original.resolutionType == ResolvedPatternType.EVALUATED)
-			return original
+		when (original.resolutionType) {
+			// Explicitly list out all types in case the enum is later expanded
+			ResolvedPatternType.EVALUATED, ResolvedPatternType.ESCAPED, ResolvedPatternType.UNDONE -> {
+				return original
+			}
+
+			ResolvedPatternType.UNRESOLVED, ResolvedPatternType.ERRORED, ResolvedPatternType.INVALID -> {}
+		}
 		val newCont = findResumePoint(continuation) ?: return original
 
 		val stack = vm.image.stack.toMutableList()


### PR DESCRIPTION
Fixes #26

Previously, `AthenaFrame` only treated `ResolvedPatternType.EVALUATED` as a "successful" evaluation in `AthenaFrame.handleAthena` (which is called by mixin code for all evaluations). However, `ResolvedPatternType.ESCAPED` and `ResolvedPatternType.UNDONE` are both 'successful' patterns in that they are not errors or mishaps, and Athena's Gambit shouldn't be stopping pattern execution on those.

This patch does not attempt to revert the `CastingImage`'s state (to reset `escapeNext` and `parenCount`). This means that Athena's Gambit may leave the vm in an unexpected state if another addon's SpecialPattern mishaps in some way (for example, Introjection from HexThings looks like it might be able to do this). I haven't tested if this is actually an issue yet (I don't think it's possible to achieve in base hexcasting), so I haven't included a fix here.